### PR TITLE
Handle and catch size limit exceeded error from clamd server.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ services:
   - docker
 
 before_install:
- - docker pull mkodockx/docker-clamav
- - docker run -d -p 3310:3310 mkodockx/docker-clamav
+ - docker pull lokori/clamav-java
+ - docker run -d -p 3310:3310 lokori/clamav-java
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM mkodockx/docker-clamav
+
+MAINTAINER Antti Virtanen <thelokori@gmail.com>
+
+# update maximum stream length to much smaller than default
+# automated tests run smoother this way
+RUN sed -i 's/^StreamMaxLength .*$/StreamMaxLength 50100/g' /etc/clamav/clamd.conf
+
+# av daemon bootstrapping
+CMD ["/bootstrap.sh"]

--- a/src/main/java/fi/solita/clamav/ClamAVClient.java
+++ b/src/main/java/fi/solita/clamav/ClamAVClient.java
@@ -102,7 +102,7 @@ public class ClamAVClient {
 
       // read reply
       try (InputStream clamIs = s.getInputStream()) {
-        return readAll(clamIs);
+    	  return assertSizeLimit(readAll(clamIs));
       }
     } 
   }
@@ -127,6 +127,14 @@ public class ClamAVClient {
   public static boolean isCleanReply(byte[] reply) {
     String r = new String(reply, StandardCharsets.US_ASCII);
     return (r.contains("OK") && !r.contains("FOUND"));
+  }
+  
+
+  private byte[] assertSizeLimit(byte[] reply) {
+    String r = new String(reply, StandardCharsets.US_ASCII);
+    if (r.startsWith("INSTREAM size limit exceeded.")) 
+    	throw new ClamAVSizeLimitException("Clamd size limit exceeded. Full reply from server: " + r);
+    return reply;
   }
 
   // byte conversion based on ASCII character set regardless of the current system locale

--- a/src/main/java/fi/solita/clamav/ClamAVSizeLimitException.java
+++ b/src/main/java/fi/solita/clamav/ClamAVSizeLimitException.java
@@ -1,0 +1,14 @@
+package fi.solita.clamav;
+
+/**
+ * Thrown if clamd size limit is exceeded during scanning.
+ * <p> 
+ * See <a href="http://linux.die.net/man/5/clamd.conf">clamd man page</a> for further information.
+ */
+public class ClamAVSizeLimitException extends RuntimeException {
+	private static final long serialVersionUID = 1L;
+
+	public ClamAVSizeLimitException(String msg) {
+		super(msg);
+	}
+}

--- a/src/test/java/fi/solita/clamav/InstreamTest.java
+++ b/src/test/java/fi/solita/clamav/InstreamTest.java
@@ -51,4 +51,10 @@ public class InstreamTest {
       byte[] r = scan(new byte[]{});
       assertTrue(ClamAVClient.isCleanReply(r));
   }
+   
+  @Test(expected = ClamAVSizeLimitException.class)
+  public void testSizeLimit() throws UnknownHostException, IOException {
+	  byte[] overlyLarge = new byte[60000];
+      scan(overlyLarge);
+  }
 }


### PR DESCRIPTION
Automated test relies on Docker image which has clamd running with artificially small MaxStreamLength setting (50100 bytes) instead of the default 10M. It seemed stupid to send 10+ megabytes during the test, even to the localhost. 

fixes issue https://github.com/solita/clamav-java/issues/5