### PR TITLE
Added support for execution simple MULTISCAN command (only one file)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Antti Virtanen <thelokori@gmail.com>
 # update maximum stream length to much smaller than default
 # automated tests run smoother this way
 RUN sed -i 's/^StreamMaxLength .*$/StreamMaxLength 50100/g' /etc/clamav/clamd.conf
-
+# For testing scan files
+ADD src/test/resources /
 # av daemon bootstrapping
 CMD ["/bootstrap.sh"]

--- a/src/main/java/fi/solita/clamav/ClamAVClient.java
+++ b/src/main/java/fi/solita/clamav/ClamAVClient.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
-import java.net.SocketException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -111,6 +110,28 @@ public class ClamAVClient {
         return assertSizeLimit(readAll(clamIs));
       }
     } 
+  }
+
+  /**
+   * Scan file by the path on the filesystem
+   * @param filepath the path to file to scan. Example: /share/attachments/virus.txt
+   * @return server reply
+   */
+  public byte[] scan(String filepath) throws IOException {
+    try (Socket socket = new Socket(hostName, port);
+         OutputStream outs = new BufferedOutputStream(socket.getOutputStream())) {
+      socket.setSoTimeout(timeout);
+
+      // handshake
+      final String multiScanCmd = "MULTISCAN" + " " + filepath;
+      outs.write(multiScanCmd.getBytes(StandardCharsets.US_ASCII));
+      outs.flush();
+
+      try (InputStream response = socket.getInputStream()) {
+        return readAll(response);
+      }
+
+    }
   }
 
   /**

--- a/src/test/java/fi/solita/clamav/InstreamTest.java
+++ b/src/test/java/fi/solita/clamav/InstreamTest.java
@@ -1,38 +1,40 @@
 package fi.solita.clamav;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.UnknownHostException;
 
-import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * These tests assume clamd is running and responding in the virtual machine. 
  */
 public class InstreamTest {
+  private final ClamAVClient client = new ClamAVClient(
+          TestConfiguration.CLAMAV_HOST, TestConfiguration.CLAMAV_PORT);
 
-  private static String CLAMAV_HOST = "localhost";
-  
-  private byte[] scan(byte[] input) throws UnknownHostException, IOException  {
-    ClamAVClient cl = new ClamAVClient(CLAMAV_HOST, 3310);
-    return cl.scan(input);
+  private byte[] scan(byte[] input) throws IOException  {
+    return client.scan(input);
   }
   
-  private byte[] scan(InputStream input) throws UnknownHostException, IOException  {
-    ClamAVClient cl = new ClamAVClient(CLAMAV_HOST, 3310);
-    return cl.scan(input);
+  private byte[] scan(InputStream input) throws IOException  {
+    return client.scan(input);
   }
+
+  private byte[] scan(String filepath) throws IOException  {
+      return client.scan(filepath);
+  }
+
   @Test
-  public void testRandomBytes() throws UnknownHostException, IOException {
+  public void testRandomBytes() throws IOException {
     byte[] r = scan("alsdklaksdla".getBytes("ASCII"));
     assertTrue(ClamAVClient.isCleanReply(r));
   }
   
   @Test
-  public void testPositive() throws UnknownHostException, IOException {
+  public void testPositive() throws IOException {
     // http://www.eicar.org/86-0-Intended-use.html
     byte[] EICAR = "X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*".getBytes("ASCII");
     byte[] r =  scan(EICAR);
@@ -40,27 +42,34 @@ public class InstreamTest {
   }
 
   @Test
-  public void testStreamChunkingWorks() throws UnknownHostException, IOException {
+  public void testStreamChunkingWorks() throws IOException {
       byte[] multipleChunks = new byte[50000];
       byte[] r = scan(multipleChunks);
       assertTrue(ClamAVClient.isCleanReply(r));
   }
   
   @Test
-  public void testChunkLimit() throws UnknownHostException, IOException {
+  public void testChunkLimit() throws IOException {
       byte[] maximumChunk = new byte[2048];
       byte[] r = scan(maximumChunk);
       assertTrue(ClamAVClient.isCleanReply(r));
   }
   
   @Test
-  public void testZeroBytes() throws UnknownHostException, IOException {
+  public void testZeroBytes() throws IOException {
       byte[] r = scan(new byte[]{});
       assertTrue(ClamAVClient.isCleanReply(r));
   }
 
   @Test(expected = ClamAVSizeLimitException.class)
-  public void testSizeLimit() throws UnknownHostException, IOException {
+  public void testSizeLimit() throws IOException {
 	  scan(new SlowInputStream());
   }
+
+  @Test
+  public void testHealthyFile() throws IOException {
+      byte[] response = scan("/healthy.file");
+      assertTrue(ClamAVClient.isCleanReply(response));
+  }
+
 }

--- a/src/test/java/fi/solita/clamav/PingTest.java
+++ b/src/test/java/fi/solita/clamav/PingTest.java
@@ -1,11 +1,10 @@
 package fi.solita.clamav;
 
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 import java.io.IOException;
-import java.net.UnknownHostException;
 
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
 /**
  * These tests assume clamd is running and responding in the virtual machine. 
@@ -13,8 +12,8 @@ import org.junit.Test;
 public class PingTest {
 
   @Test
-  public void testPingPong() throws UnknownHostException, IOException  {
-    ClamAVClient cl = new ClamAVClient("localhost", 3310);
+  public void testPingPong() throws IOException  {
+    ClamAVClient cl = new ClamAVClient(TestConfiguration.CLAMAV_HOST, TestConfiguration.CLAMAV_PORT);
     assertTrue(cl.ping());
   }
 }

--- a/src/test/java/fi/solita/clamav/TestConfiguration.java
+++ b/src/test/java/fi/solita/clamav/TestConfiguration.java
@@ -1,6 +1,6 @@
 package fi.solita.clamav;
 
 public class TestConfiguration {
-    public static String CLAMAV_HOST = "192.168.99.100";
+    public static String CLAMAV_HOST = "localhost";
     public static int CLAMAV_PORT = 3310;
 }

--- a/src/test/java/fi/solita/clamav/TestConfiguration.java
+++ b/src/test/java/fi/solita/clamav/TestConfiguration.java
@@ -1,0 +1,6 @@
+package fi.solita.clamav;
+
+public class TestConfiguration {
+    public static String CLAMAV_HOST = "192.168.99.100";
+    public static int CLAMAV_PORT = 3310;
+}

--- a/src/test/resources/healthy.file
+++ b/src/test/resources/healthy.file
@@ -1,0 +1,1 @@
+It's the healthy file


### PR DESCRIPTION
Hi all!

We are using antivirus as a service, but we need to scan file by the path on the shared volume.
I think this feature will be useful for other users of clamav-java.

Notes for PR:
1. I couldn't add a file with standard virus signature for tests, because it's an alarm for antiviruses :)
2. It's needed to create a new image for green tests (healthy.file), but building image does not exist into CI pipeline now (docker pull lokori/clamav-javal). I can add, is it needed?